### PR TITLE
Static typings, underscore properties & security vulnerabilities

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,131 @@
+export class CacheItem<I = unknown> {
+	constructor(rid: string, unsubscribe: (item: CacheItem) => void);
+	rid: string;
+	type: string | null;
+	item: I | null;
+	direct: number;
+	indirect: number;
+	subscribed: number;
+	promise: Promise<unknown> | null;
+	addSubscribed(dir: number): void;
+	setPromise<P extends Promise<unknown>>(promise: P): P;
+	setItem(item: I, type: string): this;
+	setType(type: string): this;
+	addDirect(): void;
+	removeDirect(): void;
+	resetTimeout(): void;
+	addIndirect(n?: number): void;
+}
+
+export interface ClientOptions {
+	onConnect?(): void;
+	namespace: string;
+	eventBus: any; // import("modapp-eventbus").EventBus
+}
+
+export interface Type {
+	id: string;
+	prepareData(data: unknown): unknown;
+	getFactory(rid: string): (data: unknown) => unknown;
+	syncronize(cacheItem: unknown, data: unknown): void;
+}
+
+export class ResClient {
+	constructor(hostUrlOrFactory: string | (() => WebSocket), options?: ClientOptions);
+	tryConnect: boolean;
+	connected: boolean;
+	ws: WebSocket | null;
+	requests: {};
+	reqId: number;
+	cache: Record<string, CacheItem>;
+	stale: null;
+	connectPromise: Promise<void> | null;
+	connectCallback: {
+		resolve?(): void;
+		reject?(err: Error): void;
+	} | null;
+	types: {
+		model: Type & { list: TypeList; };
+		collection: Type & { list: TypeList; };
+		error: Type;
+	};
+	readonly supportedProtocol: string;
+	connect(): Promise<void>;
+	disconnect(): void;
+	getHostUrl(): string | null;
+	on(events: string | null, handler: Function): void;
+	off(events: string | null, handler: Function): void;
+	setOnConnect(onConnect: Function): this;
+	registerModelType(pattern: string, factory: Function): this;
+	unregisterModelType(pattern: string): this;
+	registerCollectionType(pattern: string, factory: Function): this;
+	unregisterCollectionType(pattern: string): this;
+	get<T = unknown>(rid: string): Promise<T>;
+	call<T = unknown>(rid: string, method: string, params: Record<string, unknown>): Promise<T>;
+	authenticate<T = unknown>(rid: string, method: string, params: Record<string, unknown>): Promise<T>;
+	create<T = unknown>(rid: string, params: Record<string, unknown>): Promise<T>;
+	setModel<T = unknown>(id: string, props: Record<string, unknown>): Promise<T>;
+	resourceOn(rid: string, events: string | null, handler: Function): void;
+	resourceOff(rid: string, events: string | null, handler: Function): void;
+}
+
+export function isResError(input: unknown): input is ResError;
+
+export class ResCollection<O = unknown> {
+	constructor(api: ResClient, rid: string, opt?: { idCallback?: () => void; });
+	readonly length: number;
+	readonly list: Array<ResModel & O>;
+	getClient(): ResClient;
+	getResourceId(): string;
+	on(events: string | null, handler: Function): this;
+	off(events: string | null, handler: Function): this;
+	get(id: string): ResModel & O | undefined
+	indexOf(model: ResModel & O): number;
+	atIndex(index: number): ResModel & O | undefined;
+	call<T = unknown>(method: string, params: Record<string, unknown>): Promise<T>;
+	auth<T = unknown>(method: string, params: Record<string, unknown>): Promise<T>;
+	toArray(): Array<ResModel & O>;
+	toJSON(): object;
+	[Symbol.iterator](): IterableIterator<ResModel & O>;
+}
+
+export class ResError {
+	constructor(rid: string, method: string, params: Record<string, unknown>);
+	rid: string;
+	method?: string;
+	params?: Record<string, unknown>;
+	readonly code: string;
+	readonly message: string;
+	readonly data: unknown;
+	getResourceId(): string;
+}
+
+export class ResModel {
+	constructor(api: ResClient, rid: string, opt?: { definition?: object; });
+	readonly props: Record<string, unknown>;
+	getClient(): ResClient;
+	getResourceId(): string;
+	on(events: string | null, handler: Function): this;
+	off(events: string | null, handler: Function): this;
+	set<T = unknown>(props: Record<string, unknown>): T;
+	call<T = unknown>(method: string, params: Record<string, unknown>): Promise<T>;
+	auth<T = unknown>(method: string, params: Record<string, unknown>): Promise<T>;
+	toJSON(): object;
+}
+
+export class ResRef {
+	constructor(api: ResClient, rid: string);
+	readonly rid: string;
+	get<T = unknown>(): Promise<T>;
+	equals(other: ResRef): boolean;
+	toJSON(): object;
+}
+
+export class TypeList {
+	constructor(defaultFactory: Function);
+	root: {};
+	defaultFactory: Function;
+	addFactory(pattern: string, factory: Function): void;
+	removeFactory(pattern: string): Function | void;
+	getFactory(rid: string): Function;
+}

--- a/package.json
+++ b/package.json
@@ -3,18 +3,19 @@
   "version": "2.3.3",
   "description": "Resgate client implementing the RES-Client Protocol.",
   "main": "lib/index.js",
-  "types": "types/index.d.ts",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "types": "index.d.ts",
   "files": [
     "dist",
     "lib",
     "es",
-    "types"
+    "types",
+    "index.d.ts"
   ],
   "scripts": {
-    "clean": "rimraf lib dist es coverage types",
-    "build": "npm run clean && npm run types && npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min && npm run build:docs",
+    "clean": "rimraf lib dist es coverage",
+    "build": "npm run clean&& npm run build:commonjs && npm run build:es && npm run build:umd && npm run build:umd:min && npm run build:docs",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "cross-env BABEL_ENV=es NODE_ENV=development node_modules/.bin/rollup src/index.js --config --sourcemap --file dist/resclient.js",
@@ -23,8 +24,7 @@
     "eslint": "eslint src/**/*.js",
     "jest": "jest src --coverage",
     "test": "npm run eslint && npm run jest",
-    "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
-    "types": "npx -p typescript tsc src/index.js --declaration --allowJs --emitDeclarationOnly --outDir types"
+    "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^7.13.0",
     "jest": "^26.6.3",
-    "jsdoc-to-markdown": "^6.0.1",
+    "jsdoc-to-markdown": "^7.1.1",
     "mock-socket": "^7.1.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.33.1",

--- a/src/class/CacheItem.js
+++ b/src/class/CacheItem.js
@@ -9,7 +9,7 @@ class CacheItem {
 	 */
 	constructor(rid, unsubscribe) {
 		this.rid = rid;
-		this._unsubscribe = unsubscribe;
+		Object.defineProperty(this, '_unsubscribe', { value: unsubscribe, enumerable: false });
 
 		this.type = null;
 		this.item = null;

--- a/src/class/ResClient.js
+++ b/src/class/ResClient.js
@@ -155,11 +155,11 @@ class ResClient {
 		};
 
 		// Bind callbacks
-		this._handleOnopen = this._handleOnopen.bind(this);
-		this._handleOnerror = this._handleOnerror.bind(this);
-		this._handleOnmessage = this._handleOnmessage.bind(this);
-		this._handleOnclose = this._handleOnclose.bind(this);
-		this._unsubscribe = this._unsubscribe.bind(this);
+		Object.defineProperty(this, "_handleOnopen", { value: this._handleOnopen.bind(this), enumerable: false });
+		Object.defineProperty(this, "_handleOnerror", { value: this._handleOnerror.bind(this), enumerable: false });
+		Object.defineProperty(this, "_handleOnmessage", { value: this._handleOnmessage.bind(this), enumerable: false });
+		Object.defineProperty(this, "_handleOnclose", { value: this._handleOnclose.bind(this), enumerable: false });
+		Object.defineProperty(this, "_unsubscribe", { value: this._unsubscribe.bind(this), enumerable: false });
 	}
 
 	/**

--- a/src/class/ResCollection.js
+++ b/src/class/ResCollection.js
@@ -50,12 +50,12 @@ class ResCollection {
 			idCallback: { type: '?function' }
 		});
 
-		this._api = api;
-		this._rid = rid;
-		this._idCallback = opt.idCallback;
+		Object.defineProperty(this, '_api', { value: api, enumerable: false });
+		Object.defineProperty(this, '_rid', { value: rid, enumerable: false });
+		Object.defineProperty(this, '_idCallback', { value: opt.idCallback, enumerable: false });
 
-		this._map = this._idCallback ? {} : null;
-		this._list = null;
+		Object.defineProperty(this, '_map', { value: this._idCallback ? {} : null, enumerable: false, writable: true });
+		Object.defineProperty(this, '_list', { value: null, enumerable: false, writable: true });
 	}
 
 	/**

--- a/src/class/ResError.js
+++ b/src/class/ResError.js
@@ -12,9 +12,9 @@ class ResError {
 	}
 
 	__init(err) {
-		this._code = err.code || 'system.unknownError';
-		this._message = err.message || `Unknown error`;
-		this._data = err.data;
+		Object.defineProperty(this, '_code', { value: err.message || 'Unknown error', enumerable: false });
+		Object.defineProperty(this, '_message', { value: err.code || 'system.unknownError', enumerable: false });
+		Object.defineProperty(this, '_data', { value: err.data, enumerable: false });
 		return this;
 	}
 

--- a/src/class/ResModel.js
+++ b/src/class/ResModel.js
@@ -31,6 +31,9 @@ class ResModel {
 		this._rid = rid;
 		this._api = api;
 		this._props = {};
+		Object.defineProperty(this, '_rid', { value: rid, enumerable: false });
+		Object.defineProperty(this, '_api', { value: api, enumerable: false });
+		Object.defineProperty(this, '_props', { value: {}, enumerable: false });
 	}
 
 	/**

--- a/src/class/ResRef.js
+++ b/src/class/ResRef.js
@@ -9,8 +9,8 @@ class ResRef {
 	 * @param {string} rid Resource id.
 	 */
 	constructor(api, rid) {
-		this._rid = rid;
-		this._api = api;
+		Object.defineProperty(this, '_rid', { value: rid, enumerable: false });
+		Object.defineProperty(this, '_api', { value: api, enumerable: false });
 	}
 
 	/**

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,10 @@
  * Client implementation of the RES-Client Protocol.
  */
 
+export { default as CacheItem } from './class/CacheItem.js';
 export { default, isResError } from './class/ResClient.js';
 export { default as ResCollection } from './class/ResCollection.js';
+export { default as ResError } from './class/ResError.js';
 export { default as ResModel } from './class/ResModel.js';
+export { default as RefRef } from './class/ResRef.js';
+export { default as TypeList } from './class/TypeList.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "outDir": "dist"
     },
     "include": [
-        "src/**/*"
+        "src/**/*",
+        "index.d.ts"
     ],
     "exclude": [
         "node_modules",


### PR DESCRIPTION
This:
* makes typings static, as generated types are usually either lacking information or are less than helpful
* adds underscore properties via `defineProperty`, to make the non-enumerable
* updates `jsdoc-to-markdown` from **6.0.1** to **7.1.1** (I saw no changes in the generated docs)

I've left any methods/properties that begin with underscores out of the types, assuming they're "private"/"internal" methods and shouldn't be used
This ties in with jirenius/modapp-eventbus#1, the comment on line 23 can be removed if that goes through